### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/features/join-group.js
+++ b/features/join-group.js
@@ -16,7 +16,7 @@ export default {
 		const [groupInviteCode] =
 			args[0].match(
 				new RegExp(
-					"(?<=https://chat.whatsapp.com/|https://invite.whatsapp.com/)[a-zA-Z0-9]+"
+					"(?<=https://chat\\.whatsapp\\.com/|https://invite\\.whatsapp\\.com/)[a-zA-Z0-9]+"
 				)
 			) || [];
 		if (!groupInviteCode) {


### PR DESCRIPTION
Potential fix for [https://github.com/frierendv/surya/security/code-scanning/2](https://github.com/frierendv/surya/security/code-scanning/2)

To fix the problem, we need to escape the `.` characters in the regular expression to ensure they match literal dots rather than any character. This will make the regular expression more precise and prevent it from matching unintended URLs.

- Update the regular expression on line 19 to escape the `.` characters.
- Ensure that the updated regular expression still correctly matches the intended WhatsApp invite URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
