### PR TITLE
Add semaphore module exports to package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,10 @@
 		"./debounce": {
 			"import": "./dist/debounce.mjs",
 			"require": "./dist/debounce.js"
+		},
+		"./semaphore": {
+			"import": "./dist/semaphore.mjs",
+			"require": "./dist/semaphore.js"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
Include exports for the semaphore module in package.json to support both ES module and CommonJS formats.