### PR TITLE
Update peerDependencies to include file-type and undici

### DIFF
--- a/packages/baileys-utils/package.json
+++ b/packages/baileys-utils/package.json
@@ -34,7 +34,9 @@
 	"peerDependencies": {
 		"@hapi/boom": "^10.0.1",
 		"baileys": "^7.0.0-rc.3",
-		"libphonenumber-js": "^1.12.17"
+		"file-type": "^21.0.0",
+		"libphonenumber-js": "^1.12.17",
+		"undici": "^7.16.0"
 	},
 	"tsup": {
 		"clean": true,


### PR DESCRIPTION
Add file-type and undici as peer dependencies in the package.json for baileys-utils.